### PR TITLE
Add dual-lane wave combat with ranged archers

### DIFF
--- a/src/main/java/com/example/herolinewars/UnitType.java
+++ b/src/main/java/com/example/herolinewars/UnitType.java
@@ -4,25 +4,27 @@ package com.example.herolinewars;
  * Describes a unit that can be sent to the enemy lane.
  */
 public enum UnitType {
-    SCOUT("Scout", 35, 20, 6, 2, "A cheap and fast unit that increases income slightly."),
-    SOLDIER("Soldier", 50, 35, 9, 3, "Balanced melee fighter."),
-    ARCHER("Archer", 65, 30, 12, 4, "Ranged attacker that deals reliable damage."),
-    KNIGHT("Knight", 90, 55, 16, 6, "Heavy unit with strong damage."),
-    SIEGE_GOLEM("Siege Golem", 120, 80, 25, 8, "Slow but devastating against bases.");
+    SCOUT("Scout", 35, 20, 6, 2, 36, "A cheap and fast unit that increases income slightly."),
+    SOLDIER("Soldier", 50, 35, 9, 3, 40, "Balanced melee fighter."),
+    ARCHER("Archer", 65, 30, 12, 4, 160, "Ranged attacker that deals reliable damage."),
+    KNIGHT("Knight", 90, 55, 16, 6, 42, "Heavy unit with strong damage."),
+    SIEGE_GOLEM("Siege Golem", 120, 80, 25, 8, 50, "Slow but devastating against bases.");
 
     private final String displayName;
     private final int cost;
     private final int health;
     private final int damage;
     private final int incomeBonus;
+    private final int range;
     private final String description;
 
-    UnitType(String displayName, int cost, int health, int damage, int incomeBonus, String description) {
+    UnitType(String displayName, int cost, int health, int damage, int incomeBonus, int range, String description) {
         this.displayName = displayName;
         this.cost = cost;
         this.health = health;
         this.damage = damage;
         this.incomeBonus = incomeBonus;
+        this.range = range;
         this.description = description;
     }
 
@@ -44,6 +46,10 @@ public enum UnitType {
 
     public int getIncomeBonus() {
         return incomeBonus;
+    }
+
+    public int getRange() {
+        return range;
     }
 
     public String getDescription() {


### PR DESCRIPTION
## Summary
- introduce dual-lane battlefield rendering and wave-based unit deployment for each team
- allow heroes and units to engage one another, including ranged combat for archers and gold rewards for hero kills
- queue unit purchases for upcoming waves while updating HUD messaging and timers to reflect the new flow

## Testing
- `javac -d out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68e516c6da60832090253b2dfbd2a6a9