### PR TITLE
Add slot-restricted gear with attribute bonuses

### DIFF
--- a/src/main/java/com/example/herolinewars/Item.java
+++ b/src/main/java/com/example/herolinewars/Item.java
@@ -4,18 +4,55 @@ package com.example.herolinewars;
  * Represents an item that can be purchased from the shop.
  */
 public class Item {
+    /**
+     * Equipment slots restrict how many pieces of a certain type can be equipped at once.
+     */
+    public enum EquipmentSlot {
+        HELMET("Helmet", true),
+        CHESTPLATE("Chestplate", true),
+        WEAPON("Weapon", true),
+        SHIELD("Shield", true),
+        ACCESSORY("Accessory", false),
+        RING("Ring", false);
+
+        private final String displayName;
+        private final boolean unique;
+
+        EquipmentSlot(String displayName, boolean unique) {
+            this.displayName = displayName;
+            this.unique = unique;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public boolean isUnique() {
+            return unique;
+        }
+    }
+
     private final String name;
     private final int attackBonus;
     private final int defenseBonus;
     private final int cost;
     private final String description;
+    private final EquipmentSlot slot;
+    private final int strengthBonus;
+    private final int dexterityBonus;
+    private final int intelligenceBonus;
 
-    public Item(String name, int attackBonus, int defenseBonus, int cost, String description) {
+    public Item(String name, int attackBonus, int defenseBonus, int cost, String description,
+                EquipmentSlot slot, int strengthBonus, int dexterityBonus, int intelligenceBonus) {
         this.name = name;
         this.attackBonus = attackBonus;
         this.defenseBonus = defenseBonus;
         this.cost = cost;
         this.description = description;
+        this.slot = slot;
+        this.strengthBonus = strengthBonus;
+        this.dexterityBonus = dexterityBonus;
+        this.intelligenceBonus = intelligenceBonus;
     }
 
     public String getName() {
@@ -38,8 +75,49 @@ public class Item {
         return description;
     }
 
+    public EquipmentSlot getSlot() {
+        return slot;
+    }
+
+    public int getStrengthBonus() {
+        return strengthBonus;
+    }
+
+    public int getDexterityBonus() {
+        return dexterityBonus;
+    }
+
+    public int getIntelligenceBonus() {
+        return intelligenceBonus;
+    }
+
     @Override
     public String toString() {
-        return String.format("%s (Cost: %d, +%d ATK, +%d DEF) - %s", name, cost, attackBonus, defenseBonus, description);
+        StringBuilder stats = new StringBuilder();
+        if (attackBonus != 0) {
+            stats.append(String.format("+%d ATK", attackBonus));
+        }
+        if (defenseBonus != 0) {
+            appendStat(stats, String.format("+%d DEF", defenseBonus));
+        }
+        if (strengthBonus != 0) {
+            appendStat(stats, String.format("+%d STR", strengthBonus));
+        }
+        if (dexterityBonus != 0) {
+            appendStat(stats, String.format("+%d DEX", dexterityBonus));
+        }
+        if (intelligenceBonus != 0) {
+            appendStat(stats, String.format("+%d INT", intelligenceBonus));
+        }
+        String slotText = slot != null ? String.format(" [%s]", slot.getDisplayName()) : "";
+        String statSummary = stats.length() > 0 ? stats.toString() : "No bonuses";
+        return String.format("%s (Cost: %d) %s%s - %s", name, cost, statSummary, slotText, description);
+    }
+
+    private void appendStat(StringBuilder builder, String stat) {
+        if (builder.length() > 0) {
+            builder.append(", ");
+        }
+        builder.append(stat);
     }
 }


### PR DESCRIPTION
## Summary
- extend items with equipment slot metadata and attribute bonuses
- allow heroes to replace slot-locked gear while updating derived combat stats
- expand the shop inventory with stat-granting rings and new armor plus clearer item labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e524d9540083209794867c9b06a9f6