### PR TITLE
Add hero leveling and range differentiation with visual tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project contains a lightweight real-time interpretation of the classic Hero
 
 ## Gameplay overview
 
-- Choose between three hero archetypes (Ranger, Knight, or Battle Mage), each with different stats and play styles.
+- Choose between three hero archetypes (Ranger, Berserker, or Mage), each with distinct attack ranges and play styles.
 - Click anywhere on the lane to command your hero to move. They will automatically attack the opposing hero when in range.
+- Earn experience by defeating units and heroes to level up, gaining larger boosts to your primary attribute than your secondary stats.
 - Defeat the enemy hero to create openings that let you damage their base. Be careful—if you fall, the enemy will march toward yours!
 - Bases lose health when exposed; the match ends when one base is destroyed.
 


### PR DESCRIPTION
## Summary
- implement hero-specific attack ranges and experience-driven leveling that boost primary attributes
- refresh the UI with range and XP details, updated hero selection options, and new spawn/base visuals
- add a restart flow that returns to hero selection and document the new hero lineup in the README

## Testing
- `javac -d out $(find src/main/java -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68e52a68d7f08320a34a38093a250768