### PR TITLE
Add lane-switch barriers, refreshed UI, and Windows packaging script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-out/
+build/
+dist/
+*.class

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains a lightweight real-time interpretation of the classic Hero
 ## Gameplay overview
 
 - Choose between three hero archetypes (Ranger, Berserker, or Mage), each with distinct attack ranges and play styles.
-- Click anywhere on the lane to command your hero to move. They will automatically attack the opposing hero when in range.
+- Click anywhere on the lane to command your hero to move. Heroes can only change lanes by returning to the illuminated zone in front of their base, where fortified walls open briefly to let them cross.
 - Earn experience by defeating units and heroes to level up, gaining larger boosts to your primary attribute than your secondary stats.
 - Defeat the enemy hero to create openings that let you damage their base. Be careful—if you fall, the enemy will march toward yours!
 - Bases lose health when exposed; the match ends when one base is destroyed.
@@ -23,3 +23,13 @@ java -cp out com.example.herolinewars.HeroLineWarsGame
 ```
 
 When the application launches, a hero selection dialog appears. After choosing your hero, the battle begins instantly inside the Swing window.
+
+### Creating a Windows `.exe`
+
+If you have access to a Windows machine with JDK 17 or later installed, you can produce a native launcher using the provided PowerShell helper:
+
+```powershell
+pwsh scripts/create-windows-exe.ps1
+```
+
+By default the script expects `JAVA_HOME` to point to your JDK. It compiles the sources, packages them into a runnable JAR, and then invokes `jpackage` to emit `HeroLineWarsGame.exe` inside `dist\windows`. You can override the build or output directories via the script parameters (`-BuildDir`, `-OutputDir`, `-AppVersion`) if required.

--- a/scripts/create-windows-exe.ps1
+++ b/scripts/create-windows-exe.ps1
@@ -1,0 +1,76 @@
+param(
+    [string]$JdkHome = $env:JAVA_HOME,
+    [string]$BuildDir = (Join-Path $PSScriptRoot "..\build"),
+    [string]$OutputDir = (Join-Path $PSScriptRoot "..\dist\windows"),
+    [string]$AppVersion = "1.0.0"
+)
+
+if (-not $JdkHome) {
+    throw "JAVA_HOME is not set. Please point it at a JDK 17+ installation before running this script."
+}
+
+$javac = Join-Path $JdkHome "bin\javac.exe"
+$jar = Join-Path $JdkHome "bin\jar.exe"
+$jpackage = Join-Path $JdkHome "bin\jpackage.exe"
+
+foreach ($tool in @(@{Name="javac"; Path=$javac}, @{Name="jar"; Path=$jar}, @{Name="jpackage"; Path=$jpackage})) {
+    if (-not (Test-Path $tool.Path)) {
+        throw "Could not find $($tool.Name) at $($tool.Path). Make sure a full JDK is installed."
+    }
+}
+
+$sourceRoot = Join-Path $PSScriptRoot "..\src\main\java"
+if (-not (Test-Path $sourceRoot)) {
+    throw "Source directory not found: $sourceRoot"
+}
+
+$classesDir = Join-Path $BuildDir "classes"
+if (Test-Path $classesDir) {
+    Remove-Item -Recurse -Force $classesDir
+}
+New-Item -ItemType Directory -Force -Path $classesDir | Out-Null
+
+$javaFiles = Get-ChildItem -Path $sourceRoot -Recurse -Filter *.java | ForEach-Object { $_.FullName }
+if ($javaFiles.Count -eq 0) {
+    throw "No Java source files were found under $sourceRoot"
+}
+
+Write-Host "Compiling Java sources..."
+& $javac -encoding UTF-8 -d $classesDir @javaFiles
+if ($LASTEXITCODE -ne 0) {
+    throw "javac failed with exit code $LASTEXITCODE"
+}
+
+$jarPath = Join-Path $BuildDir "HeroLineWarsGame.jar"
+if (-not (Test-Path $BuildDir)) {
+    New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+}
+Write-Host "Packing application jar..."
+& $jar --create --file $jarPath --main-class com.example.herolinewars.HeroLineWarsGame -C $classesDir .
+if ($LASTEXITCODE -ne 0) {
+    throw "jar failed with exit code $LASTEXITCODE"
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+}
+
+Write-Host "Building Windows installer image with jpackage..."
+& $jpackage \
+    --type exe \
+    --name "HeroLineWarsGame" \
+    --app-version $AppVersion \
+    --vendor "Hero Line Wars" \
+    --input $BuildDir \
+    --dest $OutputDir \
+    --main-jar (Split-Path -Leaf $jarPath) \
+    --main-class "com.example.herolinewars.HeroLineWarsGame" \
+    --win-shortcut \
+    --win-menu \
+    --win-dir-chooser
+
+if ($LASTEXITCODE -ne 0) {
+    throw "jpackage failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Executable created under $OutputDir"


### PR DESCRIPTION
## Summary
- add base-adjacent lane switching rules and update hero/enemy movement to respect fortified walls
- refresh the in-game HUD and battlefield visuals with larger layout, gradients, and guidance text
- add a PowerShell helper to build a Windows .exe via jpackage and document the workflow in the README

## Testing
- javac -d out $(find src -name "*.java")

------
https://chatgpt.com/codex/tasks/task_e_68e58bba4f8c8320ac27ea1eb00c37fc