### PR TITLE
Fix camera helper methods and repaint logic

### DIFF
--- a/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
+++ b/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
@@ -2254,8 +2254,6 @@ public class HeroLineWarsGame extends JFrame {
     private void centerCameraOn(double worldX, double worldY) {
         double viewWidth = getCurrentViewWidthInWorldUnits();
         double viewHeight = getCurrentViewHeightInWorldUnits();
-        int viewWidth = getCurrentViewWidth();
-        int viewHeight = getCurrentViewHeight();
         double targetX = worldX - viewWidth / 2.0;
         double targetY = worldY - viewHeight / 2.0;
         cameraX = clamp(targetX, 0, getMaxCameraX());
@@ -2344,20 +2342,6 @@ public class HeroLineWarsGame extends JFrame {
         cameraX = clamp(desiredX, 0, getMaxCameraX());
         cameraY = clamp(desiredY, 0, getMaxCameraY());
         battlefieldPanel.repaint();
-    private double getMaxCameraX() {
-        return Math.max(0, WORLD_WIDTH - getCurrentViewWidth());
-    }
-
-    private double getMaxCameraY() {
-        return Math.max(0, WORLD_HEIGHT - getCurrentViewHeight());
-    }
-
-    private double screenToWorldX(double screenX) {
-        return cameraX + screenX;
-    }
-
-    private double screenToWorldY(double screenY) {
-        return cameraY + screenY;
     }
 
     private boolean shouldAllowPlayerLaneSwitch() {
@@ -2754,11 +2738,6 @@ public class HeroLineWarsGame extends JFrame {
             int viewWidth = getWidth();
             if (viewWidth <= 0) {
                 viewWidth = getPreferredSize().width;
-            }
-            int viewHeight = getHeight();
-            if (viewHeight <= 0) {
-                viewHeight = getPreferredSize().height;
-            }
             }
             int viewHeight = getHeight();
             if (viewHeight <= 0) {
@@ -3321,7 +3300,6 @@ public class HeroLineWarsGame extends JFrame {
         double verticalSpan = Math.max(0, bottomLimit - topLimit);
         double spawnY = topLimit + (verticalSpan <= 0 ? 0 : random.nextDouble() * verticalSpan);
         return new UnitInstance(type, getUnitBalance(type), spawnX, spawnY, topLimit, bottomLimit, fromPlayer, laneIndex);
-        return new UnitInstance(type, spawnX, spawnY, topLimit, bottomLimit, fromPlayer, laneIndex);
     }
 
     private void resolveHeroUnitCombat() {


### PR DESCRIPTION
## Summary
- restore missing closing brace in the camera zoom helper and remove duplicated helper overloads
- clean up paintComponent view size handling to avoid stray braces that broke compilation
- fix unit spawning to use the correct UnitInstance constructor signature

## Testing
- javac -d target/classes $(find src/main/java -name "*.java")

------
https://chatgpt.com/codex/tasks/task_e_68e6346ecb948320b0d3a080bdee5011