### PR TITLE
Expand base area for easier lane switching

### DIFF
--- a/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
+++ b/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
@@ -56,7 +56,7 @@ public class HeroLineWarsGame extends JFrame {
     private static final int WORLD_WIDTH = 2400;
     private static final int WORLD_HEIGHT = 1560;
     private static final int HERO_WIDTH = 36;
-    private static final int BASE_WIDTH = 80;
+    private static final int BASE_WIDTH = 120;
     private static final int BASE_MARGIN = 32;
     private static final int LANE_MARGIN = 30;
     private static final int LANE_GAP = 80;


### PR DESCRIPTION
## Summary
- increase the player and enemy base width so the base area covers more of the lane entry
- provide more room near the lane switch zone to help heroes move between lanes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6370cbac48320aa2fdeaecbde7958