### PR TITLE
Enhance hero targeting AI and developer tooling

### DIFF
--- a/src/main/java/com/example/herolinewars/Hero.java
+++ b/src/main/java/com/example/herolinewars/Hero.java
@@ -97,12 +97,36 @@ public class Hero {
         return strength + itemStrengthBonus;
     }
 
+    public int getBaseStrength() {
+        return strength;
+    }
+
     public int getDexterity() {
         return dexterity + itemDexterityBonus;
     }
 
+    public int getBaseDexterity() {
+        return dexterity;
+    }
+
     public int getIntelligence() {
         return intelligence + itemIntelligenceBonus;
+    }
+
+    public int getBaseIntelligence() {
+        return intelligence;
+    }
+
+    public int getItemStrengthBonus() {
+        return itemStrengthBonus;
+    }
+
+    public int getItemDexterityBonus() {
+        return itemDexterityBonus;
+    }
+
+    public int getItemIntelligenceBonus() {
+        return itemIntelligenceBonus;
     }
 
     public int getMaxHealth() {
@@ -354,6 +378,29 @@ public class Hero {
                 defense,
                 gold,
                 income);
+    }
+
+    public void developerSetBaseAttributes(int newStrength, int newDexterity, int newIntelligence) {
+        this.strength = Math.max(0, newStrength);
+        this.dexterity = Math.max(0, newDexterity);
+        this.intelligence = Math.max(0, newIntelligence);
+        recalculateStats();
+    }
+
+    public void developerSetGold(int amount) {
+        this.gold = Math.max(0, amount);
+    }
+
+    public void developerSetIncome(int amount) {
+        this.income = Math.max(0, amount);
+    }
+
+    public void developerSetCurrentHealth(int amount) {
+        this.currentHealth = Math.max(0, Math.min(amount, maxHealth));
+    }
+
+    public void developerSetCurrentShield(int amount) {
+        this.currentShield = Math.max(0, Math.min(amount, getMaxEnergyShield()));
     }
 
     private void recalculateStats() {


### PR DESCRIPTION
## Summary
- make units pursue and attack heroes within an extended sight radius and adjust spawn placement to form orderly ranks
- add developer settings tabs for window sizing, HUD visibility, and hero stat tuning, applying the changes live
- expose developer-friendly setters on Hero to support runtime adjustments from the new dialog

## Testing
- mvn -q -DskipTests compile *(fails: repository access forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e639a54d1883208f6da3ffbd3967af