### PR TITLE
Fix syntax errors in HeroLineWarsGame unit attacks

### DIFF
--- a/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
+++ b/src/main/java/com/example/herolinewars/HeroLineWarsGame.java
@@ -4509,21 +4509,23 @@ public class HeroLineWarsGame extends JFrame {
             if (attackCooldown > 0) {
                 return;
             }
-            if (isDead() || !isInRange(target) || target.isDead()) {
+            if (isDead() || target == null || target.isDead()) {
                 return;
             }
-            target.takeDamage(balance.getDamage());
-            if (target.isDead() && target.markDefeatHandled()) {
-                HeroLineWarsGame.this.handleUnitDefeatedByUnit(this, target);
-            if (attackCooldown <= 0 && isInRange(target)) {
-                if (type == UnitType.ARCHER) {
-                    HeroLineWarsGame.this.launchProjectile(fromPlayer, ProjectileType.ARROW, getCenterX(), getCenterY(),
-                            this, HeroTarget.unit(target));
-                } else {
-                    target.takeDamage(balance.getDamage());
-                }
-                attackCooldown = UNIT_ATTACK_COOLDOWN_TICKS;
+            if (!isInRange(target)) {
+                return;
             }
+
+            if (type == UnitType.ARCHER) {
+                HeroLineWarsGame.this.launchProjectile(fromPlayer, ProjectileType.ARROW, getCenterX(), getCenterY(), this,
+                        HeroTarget.unit(target));
+            } else {
+                target.takeDamage(balance.getDamage());
+                if (target.isDead() && target.markDefeatHandled()) {
+                    HeroLineWarsGame.this.handleUnitDefeatedByUnit(this, target);
+                }
+            }
+
             attackCooldown = UNIT_ATTACK_COOLDOWN_TICKS;
         }
 
@@ -4634,6 +4636,8 @@ public class HeroLineWarsGame extends JFrame {
             }
             defeatHandled = true;
             return true;
+        }
+
         int getDamageValue() {
             return balance.getDamage();
         }


### PR DESCRIPTION
## Summary
- restructure the `UnitInstance.tryAttack` logic to avoid invalid syntax and ensure archers fire projectiles while melee units deal damage directly
- restore the missing closing braces in `markDefeatHandled` so the file compiles again

## Testing
- mvn -q -DskipTests package *(fails: Maven Central 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e64529c9dc8320a667dc323a77d9a7