### PR TITLE
Add dedicated entry point file for starting the game

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(hero_line_wars
+    src/main.cpp
     src/HeroLineWarsGame.cpp
     src/Hero.cpp
     src/IconLibrary.cpp

--- a/src/HeroLineWarsGame.cpp
+++ b/src/HeroLineWarsGame.cpp
@@ -465,10 +465,9 @@ void HeroLineWarsGame::printBanner(const std::string& text) const {
     std::cout << "------------------------------\n";
 }
 
-}  // namespace herolinewars
-
-int main() {
-    herolinewars::HeroLineWarsGame game;
+void runGame() {
+    HeroLineWarsGame game;
     game.run();
-    return 0;
 }
+
+}  // namespace herolinewars

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,8 @@
+namespace herolinewars {
+void runGame();
+}
+
+int main() {
+    herolinewars::runGame();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a standalone `main.cpp` entry point that launches the game via a helper
- expose a `runGame` helper within the game namespace for use by the entry point
- register the new source file in the CMake build so it compiles into the executable

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68e658cb1b948320bd93f48afa08484a