### PR TITLE
Add PowerShell launcher script for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ The project uses CMake and targets C++17.
 cmake -S . -B build
 cmake --build build
 
-# Run the duel
+# Run the duel (macOS/Linux)
 ./build/hero_line_wars
 ```
+
+On Windows you can launch the game directly from PowerShell:
+
+```powershell
+pwsh -File scripts/run-game.ps1
+```
+
+The script configures (if needed) and builds the project before starting `hero_line_wars.exe`. If you prefer a different build
+directory, pass `-BuildDir` or set the `BUILD_DIR` environment variable.
 
 To create a release build:
 

--- a/scripts/run-game.ps1
+++ b/scripts/run-game.ps1
@@ -1,0 +1,72 @@
+[CmdletBinding()]
+param(
+    [string]$BuildDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-Executable {
+    param([string]$BuildDirectory)
+
+    $candidates = @()
+    $candidates += Join-Path $BuildDirectory 'hero_line_wars.exe'
+
+    if ($env:CMAKE_BUILD_TYPE) {
+        $candidates += Join-Path (Join-Path $BuildDirectory $env:CMAKE_BUILD_TYPE) 'hero_line_wars.exe'
+    }
+
+    $candidates += Join-Path (Join-Path $BuildDirectory 'Debug') 'hero_line_wars.exe'
+    $candidates += Join-Path (Join-Path $BuildDirectory 'Release') 'hero_line_wars.exe'
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    $found = Get-ChildItem -Path $BuildDirectory -Filter 'hero_line_wars.exe' -Recurse -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($found) {
+        return $found.FullName
+    }
+
+    return $null
+}
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+if (-not $BuildDir) {
+    if ($env:BUILD_DIR) {
+        $BuildDir = $env:BUILD_DIR
+    } else {
+        $BuildDir = Join-Path $projectRoot 'build'
+    }
+}
+
+$buildDirPath = Resolve-Path -Path $BuildDir -ErrorAction SilentlyContinue
+if ($buildDirPath) {
+    $BuildDir = $buildDirPath.Path
+} else {
+    $BuildDir = [System.IO.Path]::GetFullPath($BuildDir)
+}
+
+$executablePath = Find-Executable -BuildDirectory $BuildDir
+
+if (-not $executablePath) {
+    $cmakeArgs = @('-S', $projectRoot, '-B', $BuildDir)
+    if ($env:CMAKE_GENERATOR) {
+        $cmakeArgs += @('-G', $env:CMAKE_GENERATOR)
+    }
+
+    cmake @cmakeArgs
+    cmake --build $BuildDir
+
+    $executablePath = Find-Executable -BuildDirectory $BuildDir
+}
+
+if (-not $executablePath) {
+    throw "Unable to locate hero_line_wars.exe in '$BuildDir'."
+}
+
+& $executablePath @args


### PR DESCRIPTION
## Summary
- add a PowerShell `run-game` helper that configures/builds the project and locates the executable on Windows
- document the new Windows entry point in the README alongside the existing bash instructions

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68e65e7210dc8320a92e9d4c0a75ca7d