### PR TITLE
Add Windows launcher executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,11 @@ add_executable(hero_line_wars
     src/UnitType.cpp)
 
 target_include_directories(hero_line_wars PRIVATE src)
+
+if (WIN32)
+    add_executable(run_game_launcher
+        src/RunGameLauncher.cpp)
+
+    set_target_properties(run_game_launcher PROPERTIES OUTPUT_NAME "run_game")
+    add_dependencies(run_game_launcher hero_line_wars)
+endif()

--- a/README.md
+++ b/README.md
@@ -20,9 +20,20 @@ The project uses CMake and targets C++17.
 cmake -S . -B build
 cmake --build build
 
-# Run the duel
+# Run the duel (macOS/Linux)
 ./build/hero_line_wars
 ```
+
+On Windows you can launch the game directly from PowerShell:
+
+```powershell
+pwsh -File scripts/run-game.ps1
+```
+
+The script configures (if needed) and builds the project before starting `hero_line_wars.exe`. If you prefer a different build
+directory, pass `-BuildDir` or set the `BUILD_DIR` environment variable.
+
+After building with CMake, a Windows-native launcher (`run_game.exe`) is generated in the build output. Double-click it (or run it from the terminal) to locate `hero_line_wars.exe` in the build tree and start the duel without opening PowerShell.
 
 To create a release build:
 
@@ -35,4 +46,4 @@ cmake --build build/release --config Release
 ## Windows executable helper
 
 A PowerShell helper script is available under `scripts/build-windows-exe.ps1`. It configures a Release build with CMake and copy
-s the resulting executable into `dist\windows`.
+s the resulting executables into `dist\windows`.

--- a/scripts/build-windows-exe.ps1
+++ b/scripts/build-windows-exe.ps1
@@ -36,15 +36,22 @@ if (-not (Test-Path $OutputDir)) {
     New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 }
 
-$executable = Join-Path $BuildDir 'hero_line_wars.exe'
-if (-not (Test-Path $executable)) {
-    $altPath = Join-Path $BuildDir 'Release/hero_line_wars.exe'
-    if (Test-Path $altPath) {
-        $executable = $altPath
-    } else {
-        throw "Could not locate hero_line_wars.exe in the build directory."
-    }
-}
+$executables = @('hero_line_wars.exe', 'run_game.exe')
 
-Copy-Item $executable -Destination $OutputDir -Force
-Write-Host "Executable copied to $OutputDir"
+foreach ($name in $executables) {
+    $exePath = Join-Path $BuildDir $name
+    if (-not (Test-Path $exePath)) {
+        $altPath = Join-Path $BuildDir "Release/$name"
+        if (Test-Path $altPath) {
+            $exePath = $altPath
+        } elseif ($name -eq 'hero_line_wars.exe') {
+            throw "Could not locate $name in the build directory."
+        } else {
+            Write-Warning "Could not locate $name; skipping copy."
+            continue
+        }
+    }
+
+    Copy-Item $exePath -Destination $OutputDir -Force
+    Write-Host "$name copied to $OutputDir"
+}

--- a/scripts/run-game.ps1
+++ b/scripts/run-game.ps1
@@ -1,0 +1,72 @@
+[CmdletBinding()]
+param(
+    [string]$BuildDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-Executable {
+    param([string]$BuildDirectory)
+
+    $candidates = @()
+    $candidates += Join-Path $BuildDirectory 'hero_line_wars.exe'
+
+    if ($env:CMAKE_BUILD_TYPE) {
+        $candidates += Join-Path (Join-Path $BuildDirectory $env:CMAKE_BUILD_TYPE) 'hero_line_wars.exe'
+    }
+
+    $candidates += Join-Path (Join-Path $BuildDirectory 'Debug') 'hero_line_wars.exe'
+    $candidates += Join-Path (Join-Path $BuildDirectory 'Release') 'hero_line_wars.exe'
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    $found = Get-ChildItem -Path $BuildDirectory -Filter 'hero_line_wars.exe' -Recurse -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($found) {
+        return $found.FullName
+    }
+
+    return $null
+}
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+if (-not $BuildDir) {
+    if ($env:BUILD_DIR) {
+        $BuildDir = $env:BUILD_DIR
+    } else {
+        $BuildDir = Join-Path $projectRoot 'build'
+    }
+}
+
+$buildDirPath = Resolve-Path -Path $BuildDir -ErrorAction SilentlyContinue
+if ($buildDirPath) {
+    $BuildDir = $buildDirPath.Path
+} else {
+    $BuildDir = [System.IO.Path]::GetFullPath($BuildDir)
+}
+
+$executablePath = Find-Executable -BuildDirectory $BuildDir
+
+if (-not $executablePath) {
+    $cmakeArgs = @('-S', $projectRoot, '-B', $BuildDir)
+    if ($env:CMAKE_GENERATOR) {
+        $cmakeArgs += @('-G', $env:CMAKE_GENERATOR)
+    }
+
+    cmake @cmakeArgs
+    cmake --build $BuildDir
+
+    $executablePath = Find-Executable -BuildDirectory $BuildDir
+}
+
+if (-not $executablePath) {
+    throw "Unable to locate hero_line_wars.exe in '$BuildDir'."
+}
+
+& $executablePath @args

--- a/src/RunGameLauncher.cpp
+++ b/src/RunGameLauncher.cpp
@@ -1,0 +1,201 @@
+#ifdef _WIN32
+#include <windows.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace
+{
+std::filesystem::path GetExecutableDirectory()
+{
+    wchar_t buffer[MAX_PATH];
+    DWORD length = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    if (length == 0 || length == MAX_PATH)
+    {
+        throw std::runtime_error("Unable to determine module file name");
+    }
+
+    std::filesystem::path modulePath(buffer, buffer + length);
+    modulePath.remove_filename();
+    return modulePath;
+}
+
+std::filesystem::path TryCanonical(const std::filesystem::path &candidate)
+{
+    std::error_code ec;
+    std::filesystem::path resolved = std::filesystem::canonical(candidate, ec);
+    if (!ec)
+    {
+        return resolved;
+    }
+    return {};
+}
+
+std::filesystem::path FindGameExecutable(const std::filesystem::path &start)
+{
+    const std::vector<std::filesystem::path> candidates = {
+        start / L"hero_line_wars.exe",
+        start.parent_path() / L"hero_line_wars.exe",
+        start / L"Release" / L"hero_line_wars.exe",
+        start / L"Debug" / L"hero_line_wars.exe",
+        start.parent_path() / L"Release" / L"hero_line_wars.exe",
+        start.parent_path() / L"Debug" / L"hero_line_wars.exe"};
+
+    for (const auto &candidate : candidates)
+    {
+        if (candidate.empty())
+        {
+            continue;
+        }
+
+        std::error_code existsError;
+        if (std::filesystem::exists(candidate, existsError) && !existsError)
+        {
+            std::filesystem::path resolved = TryCanonical(candidate);
+            if (!resolved.empty())
+            {
+                return resolved;
+            }
+        }
+    }
+
+    std::error_code iteratorError;
+    std::filesystem::recursive_directory_iterator it(
+        start,
+        std::filesystem::directory_options::skip_permission_denied,
+        iteratorError);
+
+    for (std::filesystem::recursive_directory_iterator end; it != end; it.increment(iteratorError))
+    {
+        if (iteratorError)
+        {
+            iteratorError.clear();
+            continue;
+        }
+
+        if (!it->is_regular_file())
+        {
+            continue;
+        }
+
+        if (it->path().filename() == L"hero_line_wars.exe")
+        {
+            std::filesystem::path resolved = TryCanonical(it->path());
+            if (!resolved.empty())
+            {
+                return resolved;
+            }
+        }
+    }
+
+    return {};
+}
+
+std::wstring BuildCommandLine(const std::filesystem::path &exe, int argc, wchar_t *argv[])
+{
+    std::wstring command = L"\"" + exe.wstring() + L"\"";
+    for (int i = 1; i < argc; ++i)
+    {
+        command += L" \"";
+        command += argv[i];
+        command += L"\"";
+    }
+
+    return command;
+}
+
+std::wstring Utf8ToWide(const std::string &text)
+{
+    if (text.empty())
+    {
+        return std::wstring();
+    }
+
+    int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+    if (sizeNeeded <= 0)
+    {
+        return std::wstring(L"(unable to decode error message)");
+    }
+
+    std::wstring wide(static_cast<std::size_t>(sizeNeeded) - 1, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wide.data(), sizeNeeded);
+    return wide;
+}
+
+[[noreturn]] void AbortWithMessage(const std::wstring &message)
+{
+    std::wcerr << message << std::endl;
+    MessageBoxW(nullptr, message.c_str(), L"Hero Line Wars", MB_ICONERROR | MB_OK);
+    std::exit(EXIT_FAILURE);
+}
+}
+
+int wmain(int argc, wchar_t *argv[])
+{
+    try
+    {
+        const std::filesystem::path exeDir = GetExecutableDirectory();
+        const std::filesystem::path gameExecutable = FindGameExecutable(exeDir);
+
+        if (gameExecutable.empty())
+        {
+            AbortWithMessage(L"Unable to locate hero_line_wars.exe. Build the project first using CMake.");
+        }
+
+        std::wstring commandLine = BuildCommandLine(gameExecutable, argc, argv);
+        std::vector<wchar_t> commandBuffer(commandLine.begin(), commandLine.end());
+        commandBuffer.push_back(L'\0');
+
+        std::wstring workingDirectory = gameExecutable.parent_path().wstring();
+
+        STARTUPINFOW startupInfo{};
+        PROCESS_INFORMATION processInfo{};
+        startupInfo.cb = sizeof(startupInfo);
+
+        BOOL created = CreateProcessW(
+            nullptr,
+            commandBuffer.data(),
+            nullptr,
+            nullptr,
+            FALSE,
+            0,
+            nullptr,
+            workingDirectory.c_str(),
+            &startupInfo,
+            &processInfo);
+
+        if (!created)
+        {
+            DWORD error = GetLastError();
+            std::wstring message = L"Failed to launch hero_line_wars.exe (error code " + std::to_wstring(error) + L").";
+            AbortWithMessage(message);
+        }
+
+        CloseHandle(processInfo.hThread);
+        WaitForSingleObject(processInfo.hProcess, INFINITE);
+        DWORD exitCode = EXIT_FAILURE;
+        if (!GetExitCodeProcess(processInfo.hProcess, &exitCode))
+        {
+            exitCode = EXIT_FAILURE;
+        }
+        CloseHandle(processInfo.hProcess);
+
+        return static_cast<int>(exitCode);
+    }
+    catch (const std::exception &ex)
+    {
+        AbortWithMessage(L"Launcher error: " + Utf8ToWide(ex.what()));
+    }
+    catch (...)
+    {
+        AbortWithMessage(L"An unknown error occurred while launching the game.");
+    }
+
+    return EXIT_FAILURE;
+}
+#endif


### PR DESCRIPTION
## Summary
- add a Windows-only C++ launcher that locates hero_line_wars.exe and runs it
- hook the launcher into the CMake build and ensure the release helper copies it alongside the game
- document the new run_game.exe workflow for Windows players

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68e65e7210dc8320a92e9d4c0a75ca7d