### PR TITLE
Make Windows launcher build as GUI executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(hero_line_wars PRIVATE src)
 if (WIN32)
     add_executable(run_game_launcher
         src/RunGameLauncher.cpp)
+    set_target_properties(run_game_launcher PROPERTIES WIN32_EXECUTABLE ON)
 else()
     add_executable(run_game_launcher
         src/RunGameLauncherPosix.cpp)

--- a/src/RunGameLauncher.cpp
+++ b/src/RunGameLauncher.cpp
@@ -198,4 +198,12 @@ int wmain(int argc, wchar_t *argv[])
 
     return EXIT_FAILURE;
 }
+
+extern int __argc;
+extern wchar_t **__wargv;
+
+int APIENTRY wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
+{
+    return wmain(__argc, __wargv);
+}
 #endif


### PR DESCRIPTION
## Summary
- mark the Windows launcher target as a GUI executable so it produces a clickable run_game.exe
- forward WinMain to the existing wmain implementation to keep command-line processing intact when double-clicked

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68e67056d8b08320bc256cc1385362c3