### PR TITLE
Add standalone launch scripts for Hero Line Wars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
+.launcher-build/
 *.class

--- a/README.md
+++ b/README.md
@@ -24,29 +24,23 @@ cmake --build build
 ./build/hero_line_wars
 ```
 
-You can now use the cross-platform launcher to build (if necessary) and start the duel
-without opening an IDE or touching CMake:
+You can now use the provided launchers to build (if necessary) and start the duel
+without touching CMake, Python, or an IDE. From the project root run:
 
 ```bash
-python scripts/launch-game.py -- [game arguments]
+./launch-game.sh [game arguments]
 ```
 
-Useful options include `--build-dir` to choose the output folder, `--clean` to force a
-fresh build, `--compiler` to select a specific toolchain, `--skip-build` when you only
-want to run an already compiled executable, and `--build-only` if you merely need the
-binary without launching it straight away.
-
-The launcher is a thin Python script that calls a local C++17 compiler directly, so as
-long as you have either `g++`, `clang++`, or `cl` available on your `PATH` you can jump
-straight into the duel.
-
-On Windows you can run the helper batch script from Command Prompt:
+or on Windows double-click `launch-game.cmd` (or run it from Command Prompt):
 
 ```cmd
-scripts\run-game.cmd
+launch-game.cmd [game arguments]
 ```
 
-The script configures (if needed) and builds the project before starting `hero_line_wars.exe`. To use a different build directory, pass `--build-dir <path>` or set the `BUILD_DIR` environment variable. If you already have a preferred CMake generator, set `CMAKE_GENERATOR` before invoking the script. Otherwise it attempts to pick a sensible default (preferring Ninja when available, and falling back to Visual Studio 2022 when MSBuild is detected) so that you don't need the legacy `nmake` tool on your `PATH`.
+Both scripts locate a native C++17 compiler on your `PATH`, rebuild the game only when
+the sources change, and then start the freshly built `hero_line_wars` executable. If you
+already have a compiled binary in the script's private `.launcher-build` directory the
+launch step is instant.
 
 After building with CMake, a platform-native launcher (`run_game` on macOS/Linux, `run_game.exe` on Windows) is generated in the build output. Double-click it (or run it from the terminal) to locate the appropriate `hero_line_wars` binary in the build tree and start the duel without scripting.
 

--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -1,0 +1,75 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+set "BUILD_DIR=%SCRIPT_DIR%\.launcher-build"
+set "GAME_EXE=%BUILD_DIR%\hero_line_wars.exe"
+set "SRC_DIR=%SCRIPT_DIR%\src"
+set "SOURCE_FILES=main.cpp HeroLineWarsGame.cpp Hero.cpp IconLibrary.cpp Item.cpp Team.cpp UnitType.cpp"
+
+call :find_compiler
+if errorlevel 1 exit /b 1
+
+call :needs_rebuild
+if errorlevel 1 (
+    call :compile
+    if errorlevel 1 exit /b 1
+)
+
+pushd "%BUILD_DIR%" >nul 2>&1
+"%GAME_EXE%" %*
+set "EXITCODE=%ERRORLEVEL%"
+popd >nul 2>&1
+exit /b %EXITCODE%
+
+:find_compiler
+for %%C in (cl.exe g++.exe clang++.exe) do (
+    for /f "usebackq delims=" %%P in (`where %%C 2^>nul`) do (
+        set "COMPILER_CMD=%%P"
+        set "COMPILER_BASENAME=%%~nP"
+        goto :compiler_found
+    )
+)
+echo [launcher] Could not find cl.exe, g++.exe, or clang++.exe on PATH.
+exit /b 1
+:compiler_found
+set "COMPILER_TYPE=!COMPILER_BASENAME!"
+exit /b 0
+
+:needs_rebuild
+if not exist "%GAME_EXE%" exit /b 1
+for %%S in (%SOURCE_FILES%) do (
+    set "FULL_PATH=%SRC_DIR%\%%S"
+    if exist "!FULL_PATH!" (
+        for %%F in ("!FULL_PATH!") do (
+            for %%B in ("%GAME_EXE%") do (
+                if %%~tF GTR %%~tB exit /b 1
+            )
+        )
+    )
+)
+exit /b 0
+
+:compile
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "SOURCE_ARGS="
+for %%S in (%SOURCE_FILES%) do (
+    set "SOURCE_ARGS=!SOURCE_ARGS! \"%SRC_DIR%\%%S\""
+)
+if /i "!COMPILER_TYPE!"=="cl" (
+    pushd "%BUILD_DIR%" >nul 2>&1
+    echo [launcher] Building hero_line_wars with cl.exe...
+    call "!COMPILER_CMD!" /nologo /std:c++17 /EHsc /O2 /I"%SRC_DIR%" !SOURCE_ARGS! /Fehero_line_wars.exe
+    set "STATUS=%ERRORLEVEL%"
+    popd >nul 2>&1
+) else (
+    echo [launcher] Building hero_line_wars with !COMPILER_BASENAME!... 
+    "!COMPILER_CMD!" -std=c++17 -O2 -I"%SRC_DIR%" !SOURCE_ARGS! -o "%GAME_EXE%"
+    set "STATUS=%ERRORLEVEL%"
+)
+if not "%STATUS%"=="0" (
+    echo [launcher] Failed to build hero_line_wars.
+    exit /b %STATUS%
+)
+exit /b 0

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/.launcher-build"
+GAME_BIN="$BUILD_DIR/hero_line_wars"
+SRC_DIR="$SCRIPT_DIR/src"
+
+SOURCES=(
+  "main.cpp"
+  "HeroLineWarsGame.cpp"
+  "Hero.cpp"
+  "IconLibrary.cpp"
+  "Item.cpp"
+  "Team.cpp"
+  "UnitType.cpp"
+)
+
+choose_compiler() {
+  if command -v g++ >/dev/null 2>&1; then
+    echo "g++"
+    return 0
+  fi
+  if command -v clang++ >/dev/null 2>&1; then
+    echo "clang++"
+    return 0
+  fi
+  return 1
+}
+
+CXX="$(choose_compiler || true)"
+if [[ -z "$CXX" ]]; then
+  echo "Error: Unable to find a C++17 compiler (g++ or clang++) on PATH." >&2
+  exit 1
+fi
+
+needs_rebuild=0
+if [[ ! -x "$GAME_BIN" ]]; then
+  needs_rebuild=1
+else
+  for source in "${SOURCES[@]}"; do
+    if [[ "$SRC_DIR/$source" -nt "$GAME_BIN" ]]; then
+      needs_rebuild=1
+      break
+    fi
+  done
+fi
+
+if [[ "$needs_rebuild" -eq 1 ]]; then
+  mkdir -p "$BUILD_DIR"
+  echo "[launcher] Building hero_line_wars with $CXX..."
+  "$CXX" -std=c++17 -O2 -pipe -I"$SRC_DIR" \
+    "${SOURCES[@]/#/$SRC_DIR/}" \
+    -o "$GAME_BIN"
+  echo "[launcher] Build finished."
+fi
+
+echo "[launcher] Starting Hero Line Wars..."
+cd "$BUILD_DIR"
+exec "$GAME_BIN" "$@"


### PR DESCRIPTION
## Summary
- add cross-platform launch scripts that build the game with a locally available compiler and start it immediately
- document the new launcher entry points in the README for Linux/macOS and Windows users
- ignore the `.launcher-build` cache created by the launcher scripts

## Testing
- ./launch-game.sh --help (terminated after confirming the game starts)

------
https://chatgpt.com/codex/tasks/task_e_68e68cbd0b488320af2fa0d8be178ae1