### PR TITLE
Add embedded Windows launcher fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ launch step is instant.
 
 After building with CMake, a platform-native launcher (`run_game` on macOS/Linux, `run_game.exe` on Windows) is generated in the build output. Double-click it (or run it from the terminal) to locate the appropriate `hero_line_wars` binary in the build tree and start the duel without scripting.
 
+On Windows the launcher now bundles a fallback build of the game. If no standalone `hero_line_wars.exe` sits next to the launcher, it automatically boots the embedded version instead. That means you can ship **just** the `run_game.exe` produced by CMake to another Windows PC that lacks developer tools—double-clicking it starts the duel immediately.
+
 ```bash
 cmake -S . -B build/release -DCMAKE_BUILD_TYPE=Release
 cmake --build build/release --config Release

--- a/src/HeroLineWarsGame.cpp
+++ b/src/HeroLineWarsGame.cpp
@@ -1,4 +1,5 @@
 #include "Hero.h"
+#include "HeroLineWarsGame.h"
 #include "IconLibrary.h"
 #include "Item.h"
 #include "Team.h"

--- a/src/HeroLineWarsGame.h
+++ b/src/HeroLineWarsGame.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace herolinewars
+{
+void runGame();
+}
+

--- a/src/RunGameLauncher.cpp
+++ b/src/RunGameLauncher.cpp
@@ -1,6 +1,8 @@
 #ifdef _WIN32
 #include <windows.h>
 
+#include "HeroLineWarsGame.h"
+
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -127,6 +129,28 @@ std::wstring Utf8ToWide(const std::string &text)
     return wide;
 }
 
+[[noreturn]] void AbortWithMessage(const std::wstring &message);
+
+int RunEmbeddedGame()
+{
+    try
+    {
+        std::wcout << L"Launching embedded Hero Line Wars build..." << std::endl;
+        herolinewars::runGame();
+        return EXIT_SUCCESS;
+    }
+    catch (const std::exception &ex)
+    {
+        AbortWithMessage(L"Standalone launcher error: " + Utf8ToWide(ex.what()));
+    }
+    catch (...)
+    {
+        AbortWithMessage(L"An unknown error occurred while running the embedded game.");
+    }
+
+    return EXIT_FAILURE;
+}
+
 [[noreturn]] void AbortWithMessage(const std::wstring &message)
 {
     std::wcerr << message << std::endl;
@@ -144,7 +168,9 @@ int wmain(int argc, wchar_t *argv[])
 
         if (gameExecutable.empty())
         {
-            AbortWithMessage(L"Unable to locate hero_line_wars.exe. Build the project first using CMake.");
+            std::wcerr << L"Unable to locate hero_line_wars.exe next to the launcher." << std::endl;
+            std::wcerr << L"Falling back to the embedded standalone game." << std::endl;
+            return RunEmbeddedGame();
         }
 
         std::wstring commandLine = BuildCommandLine(gameExecutable, argc, argv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,4 @@
-namespace herolinewars {
-void runGame();
-}
+#include "HeroLineWarsGame.h"
 
 int main() {
     herolinewars::runGame();


### PR DESCRIPTION
## Summary
- add a lightweight header for the game entry point and include it from the launcher
- teach the Windows launcher to fall back to an embedded copy of the game when the external executable is missing
- document that run_game.exe can now be distributed by itself on Windows

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e69681b9448320b9c294ae8e4e69aa