### PR TITLE
Document .NET SDK prerequisite for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ ve.
 
 ### Windows (.NET single-file build)
 
+> **Prerequisite:** Install the [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download) if the `dotnet` command is not already available on your `PATH`. You can verify the installation with `dotnet --version` from a new terminal session.
+
 The repository ships with a C# console port that can be published as a standalone Windows executable. From any machine with the .NET 6 SDK installed, run:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a prerequisite note in the Windows build instructions explaining that the .NET 6 SDK must be installed
- point readers to dotnet --version to confirm installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6d3753b4c8320be0ec9dc4a0c018c