### PR TITLE
Fix ambiguous Math.Round call in Hero stat calculation

### DIFF
--- a/dotnet/HeroLineWars/Hero.cs
+++ b/dotnet/HeroLineWars/Hero.cs
@@ -315,7 +315,7 @@ internal sealed class Hero
     public void RecalculateStats()
     {
         var totalStrength = GetStrength();
-        MaxHealth = (int)Math.Round(BaseMaxHealth + totalStrength * HealthPerStrength);
+        MaxHealth = (int)Math.Round(BaseMaxHealth + totalStrength * (double)HealthPerStrength);
         if (CurrentHealth > MaxHealth)
         {
             CurrentHealth = MaxHealth;


### PR DESCRIPTION
## Summary
- cast the max health calculation to double before rounding to avoid an ambiguous Math.Round overload

## Testing
- `dotnet publish dotnet/HeroLineWars/HeroLineWars.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true` *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d5a86d808320815d20e33f2d6e1a